### PR TITLE
Fix parsing mpeg 2.5 frames

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -227,6 +227,11 @@
             "01": lib.v2l3Bitrates,
             "10": lib.v2l2Bitrates,
             "11": lib.v2l1Bitrates
+        },
+        "00": {
+          "01": lib.v2l3Bitrates,
+          "10": lib.v2l2Bitrates,
+          "11": lib.v2l1Bitrates
         }
     };
 
@@ -253,7 +258,7 @@
 
     //
     lib.sampleLengthMap = {
-        "01": lib.v2SampleLengths,
+        "00": lib.v2SampleLengths,
         "10": lib.v2SampleLengths,
         "11": lib.v1SampleLengths
     };


### PR DESCRIPTION
This adds some tests for the mpeg layer III files included in the audio-test-data package, and fixes `sampleLengthMap` & `bitrateMap` for mpeg 2.5.

I don't think sampleLengthMap was quite right when I first added it here: https://github.com/biril/mp3-parser/commit/1bf1b90e77844c8741184c501af59f859623cca8#diff-328c47b638336c765a36ff719ccdae57R256.   "01" is the "Reserved" mpeg version - it ought to be using "00" for mpeg 2.5 (which uses the same sample lengths as mpeg 2).